### PR TITLE
Add workflow to publish docker image

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,35 @@
+# see https://github.com/marketplace/actions/build-and-push-docker-images
+on:
+  push:
+    branches:
+      - master
+      - ci
+    paths:
+      - "Dockerfile"
+
+name: release image
+
+jobs:
+  release-image:
+    runs-on: ubuntu-latest
+    # build-push-action use git context,
+    # do not need to use actions/checkout
+    steps:
+      - 
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - 
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - 
+        name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          tags: skyleaworlder/tut-env:v1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,23 @@
+on:
+  push:
+    branches:
+      - master
+      - ci
+  pull_request:
+    branches:
+      - master
+
+name: test docker image
+
+jobs:
+  docker-compose:
+    runs-on: ubuntu-latest
+    steps:
+      - 
+        name: checkout
+        uses: actions/checkout@v2
+      - 
+        name: run container
+        run: |
+          docker compose up -d
+ 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 FROM ubuntu:latest
+
+# Docker image: tut-env:v1 
 LABEL organization="TJ-CSCCG"
 LABEL maintainer="skyleaworlder"
 LABEL version="v1"

--- a/README.md
+++ b/README.md
@@ -22,33 +22,35 @@
 
 ### 3. 构建镜像 & 运行容器
 
-注：视网络情况，首次构建镜像可能需要 12 min 左右；容器体积约为 974 MB。
-
 #### i. docker compose (recommand)
 
 ```shell
-> docker compose build # you can still use compose v1 by docker-compose
-> docker compose up -d
+> docker compose up -d # you can still use compose v1 by docker-compose
 ```
 
-#### ii. Docker
+镜像地址：https://hub.docker.com/repository/docker/skyleaworlder/tut-env
+
+#### ii. Docker（本地构建镜像）
 
 ```shell
 > docker build -t tut-env:v1 .
 > docker run -itd --name tut-env tut-env:v1
 ```
 
+注：视网络情况，首次构建镜像可能需要 12 min 左右；容器体积约为 974 MB。
+
 ### 4. 编译 LaTeX 文档
 
-容器内使用 XeLaTeX 编译文档。
+在宿主机的 thesis 工作目录执行 `compile` 指令：
 
 ```shell
-> # make sure that you are located at thesis path
+> # you are in Host OS now
+> # function "compile" will help you compile document in Container OS
 > cd <your-thesis-repository-path>
 > compile
 ```
 
-可以在宿主机执行 tlmgr-install 直接下载宏包到容器中：
+还可以在宿主机执行 tlmgr-install 将宏包直接下载到容器中：
 
 ```shell
 > # install algorithms and cases into container
@@ -59,3 +61,4 @@
 
 * 宿主机目前仅良好支持 Linux。
 * 非 Linux 用户可使用 VSCode 连接 Linux 服务器，并根据上述指引搭建环境。
+* 容器内使用 XeLaTeX 编译文档。

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,5 +3,5 @@ services:
   tut-env:
     container_name: tut-env
     image: tut-env:v1
-    build: .
+    build: skyleaworlder/tut-env:v1
     tty: true

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,6 +2,5 @@ version: '3'
 services:
   tut-env:
     container_name: tut-env
-    image: tut-env:v1
-    build: skyleaworlder/tut-env:v1
+    image: skyleaworlder/tut-env:v1
     tty: true


### PR DESCRIPTION
Close #3 

* 使用 GitHub Actions ([Build and push Docker images](https://github.com/marketplace/actions/build-and-push-docker-images))；
* 对非 Dockerfile 的修改不会触发 workflow；
* 此后可从 docker.io 直接 pull。